### PR TITLE
Support multiversion clients in server; peer-specific protocol versions

### DIFF
--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -5155,11 +5155,11 @@ bool ProcessOfflineNetworkPacket( SystemAddress systemAddress, const char *data,
 			//RAKNET_DEBUG_PRINTF("%i:IOCR, ", __LINE__);
 
 			char remoteProtocol=data[1+sizeof(OFFLINE_MESSAGE_DATA_ID)];
-			if ((remoteProtocol != protocolVersion_) && !(allowClientsWithNewerVersion && (remoteProtocol < protocolVersion_)))
+			if ((remoteProtocol != rakPeer->protocolVersion_) && !(rakPeer->allowClientsWithNewerVersion && (remoteProtocol < rakPeer->protocolVersion_)))
 			{
 				RakNet::BitStream bs;
 				bs.Write((MessageID)ID_INCOMPATIBLE_PROTOCOL_VERSION);
-				bs.Write((unsigned char)protocolVersion_);
+				bs.Write((unsigned char)rakPeer->protocolVersion_);
 				bs.WriteAlignedBytes((const unsigned char*) OFFLINE_MESSAGE_DATA_ID, sizeof(OFFLINE_MESSAGE_DATA_ID));
 				bs.Write(rakPeer->GetGuidFromSystemAddress(UNASSIGNED_SYSTEM_ADDRESS));
 

--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -5155,7 +5155,7 @@ bool ProcessOfflineNetworkPacket( SystemAddress systemAddress, const char *data,
 			//RAKNET_DEBUG_PRINTF("%i:IOCR, ", __LINE__);
 
 			char remoteProtocol=data[1+sizeof(OFFLINE_MESSAGE_DATA_ID)];
-			if ((remoteProtocol != protocolVersion_) || (allowClientsWithNewerVersion && (remoteProtocol < protocolVersion_)))
+			if ((remoteProtocol != protocolVersion_) && !(allowClientsWithNewerVersion && (remoteProtocol < protocolVersion_)))
 			{
 				RakNet::BitStream bs;
 				bs.Write((MessageID)ID_INCOMPATIBLE_PROTOCOL_VERSION);

--- a/Source/RakPeer.cpp
+++ b/Source/RakPeer.cpp
@@ -53,9 +53,6 @@
 #include "SuperFastHash.h"
 #include "RakAlloca.h"
 #include "WSAStartupSingleton.h"
-#include "RuntimeVars.h" // Andromeda
-
-#define RAKNET_PROTOCOL_VERSION RakNetProtocolVersion
 
 #ifdef USE_THREADED_SEND
 #include "SendToThread.h"
@@ -5158,11 +5155,11 @@ bool ProcessOfflineNetworkPacket( SystemAddress systemAddress, const char *data,
 			//RAKNET_DEBUG_PRINTF("%i:IOCR, ", __LINE__);
 
 			char remoteProtocol=data[1+sizeof(OFFLINE_MESSAGE_DATA_ID)];
-			if (remoteProtocol!=RAKNET_PROTOCOL_VERSION)
+			if ((remoteProtocol != protocolVersion_) || (allowClientsWithNewerVersion && (remoteProtocol < protocolVersion_)))
 			{
 				RakNet::BitStream bs;
 				bs.Write((MessageID)ID_INCOMPATIBLE_PROTOCOL_VERSION);
-				bs.Write((unsigned char)RAKNET_PROTOCOL_VERSION);
+				bs.Write((unsigned char)protocolVersion_);
 				bs.WriteAlignedBytes((const unsigned char*) OFFLINE_MESSAGE_DATA_ID, sizeof(OFFLINE_MESSAGE_DATA_ID));
 				bs.Write(rakPeer->GetGuidFromSystemAddress(UNASSIGNED_SYSTEM_ADDRESS));
 
@@ -5792,7 +5789,7 @@ bool RakPeer::RunUpdateCycle(BitStream &updateBitStream )
 					//WriteOutOfBandHeader(&bitStream, ID_USER_PACKET_ENUM);
 					bitStream.Write((MessageID)ID_OPEN_CONNECTION_REQUEST_1);
 					bitStream.WriteAlignedBytes((const unsigned char*) OFFLINE_MESSAGE_DATA_ID, sizeof(OFFLINE_MESSAGE_DATA_ID));
-					bitStream.Write((MessageID)RAKNET_PROTOCOL_VERSION);
+					bitStream.Write((MessageID)protocolVersion_);
 					bitStream.PadWithZeroToByteLength(mtuSizes[MTUSizeIndex] - UDP_HEADER_SIZE);
 
 					char str[256];

--- a/Source/RakPeer.h
+++ b/Source/RakPeer.h
@@ -681,13 +681,6 @@ public:
 		// Reference counted socket to send back on
 		RakNetSocket2* rakNetSocket;
 		SystemIndex remoteSystemIndex;
-
-		// Begin Patch
-		// Permits clients with a newer RakNet protocol version to join server anyway
-		bool allowClientsWithNewerVersion = false;
-		inline void SetProtocolVersion(int version) { this->protocolVersion_ = version; }
-		inline int GetProtocolVersion() { return this->protocolVersion_; }
-		// End Patch
 #if LIBCAT_SECURITY==1
 		// Cached answer used internally by RakPeer to prevent DoS attacks based on the connexion handshake
 		char answer[cat::EasyHandshake::ANSWER_BYTES];
@@ -763,8 +756,6 @@ protected:
 	
 	// RakNet::LocklessUint32_t isRecvFromLoopThreadActive;
 
-
-	int protocolVersion_ = RAKNET_PROTOCOL_VERSION; // Andromeda
 	bool occasionalPing;  /// Do we occasionally ping the other systems?*/
 	///Store the maximum number of peers allowed to connect
 	unsigned int maximumNumberOfPeers;

--- a/Source/RakPeer.h
+++ b/Source/RakPeer.h
@@ -685,7 +685,8 @@ public:
 		// Begin Patch
 		// Permits clients with a newer RakNet protocol version to join server anyway
 		bool allowClientsWithNewerVersion = false;
-		int protocolVersion_ = RAKNET_PROTOCOL_VERSION;
+		inline void SetProtocolVersion(int version) { this->protocolVersion_ = version; }
+		inline int GetProtocolVersion() { return this->protocolVersion_; }
 		// End Patch
 #if LIBCAT_SECURITY==1
 		// Cached answer used internally by RakPeer to prevent DoS attacks based on the connexion handshake
@@ -763,6 +764,7 @@ protected:
 	// RakNet::LocklessUint32_t isRecvFromLoopThreadActive;
 
 
+	int protocolVersion_ = RAKNET_PROTOCOL_VERSION; // Andromeda
 	bool occasionalPing;  /// Do we occasionally ping the other systems?*/
 	///Store the maximum number of peers allowed to connect
 	unsigned int maximumNumberOfPeers;

--- a/Source/RakPeer.h
+++ b/Source/RakPeer.h
@@ -682,6 +682,11 @@ public:
 		RakNetSocket2* rakNetSocket;
 		SystemIndex remoteSystemIndex;
 
+		// Begin Patch
+		// Permits clients with a newer RakNet protocol version to join server anyway
+		bool allowClientsWithNewerVersion = false;
+		int protocolVersion_ = RAKNET_PROTOCOL_VERSION;
+		// End Patch
 #if LIBCAT_SECURITY==1
 		// Cached answer used internally by RakPeer to prevent DoS attacks based on the connexion handshake
 		char answer[cat::EasyHandshake::ANSWER_BYTES];

--- a/Source/RakPeerInterface.h
+++ b/Source/RakPeerInterface.h
@@ -24,6 +24,7 @@
 #include "DS_List.h"
 #include "RakNetSmartPtr.h"
 #include "RakNetSocket2.h"
+#include "RakNetVersion.h"
 
 namespace RakNet
 {
@@ -605,6 +606,13 @@ public:
 	/// \internal
 	virtual bool SendOutOfBand(const char *host, unsigned short remotePort, const char *data, BitSize_t dataLength, unsigned connectionSocketIndex=0 )=0;
 
+	// Begin Patch
+	// Permits clients with a newer RakNet protocol version to join server anyway
+	bool allowClientsWithNewerVersion = false;
+	int protocolVersion_ = RAKNET_PROTOCOL_VERSION; // Andromeda
+	inline void SetProtocolVersion(int version) { this->protocolVersion_ = version; }
+	inline int GetProtocolVersion() { return this->protocolVersion_; }
+	// End Patch
 }
 // #if defined(SN_TARGET_PSP2)
 // __attribute__((aligned(8)))


### PR DESCRIPTION
* Add option to RakPeer to enable clients with a protocol version less than our server's set protocol version to connect anyway (assumes back-compat in protocol)
* RakPeer specific protocol versions to avoid global versioning collisions